### PR TITLE
fix: 非 Forum Topic 群忽略 message_thread_id 的 session 分流，修复普通回复线程导致上下文断裂

### DIFF
--- a/codecs/__init__.py
+++ b/codecs/__init__.py
@@ -39,6 +39,8 @@ class TelegramInboundCodec:
         user_id = from_user.get("id")
         message_thread_id = msg.get("message_thread_id")
         direct_messages_topic_id = msg.get("direct_messages_topic_id")
+        is_topic_message = msg.get("is_topic_message", False)
+        grouping_thread_id = message_thread_id if is_topic_message else None
 
         if user_id is None or chat_id is None:
             return None
@@ -66,7 +68,7 @@ class TelegramInboundCodec:
 
         # 群聊信息
         if is_group_chat(chat_type):
-            virtual_group_id = build_topic_group_id(chat_id, message_thread_id, direct_messages_topic_id)
+            virtual_group_id = build_topic_group_id(chat_id, grouping_thread_id, direct_messages_topic_id)
             self._logger.debug(
                 "Telegram 入站群聊映射: "
                 f"chat_id={chat_id}, "


### PR DESCRIPTION
## 修复：非 Forum Topic 群回复消息导致 session 分裂

### 问题

使用 MaiBot-Telegram-Adapter 后，同一个 Telegram 群聊频繁创建新 session，
日志中出现多个不同的 `session_id` 指向同一个群，上下文无法连续。

其他平台（如 QQ）无此问题。

### 根因

在 `codecs/__init__.py` 的 `build_message_dict()` 中，`message_thread_id`
被无差别地用于构造虚拟 `group_id`。

Telegram Bot API 行为：**普通超级群**（非 Forum Topic）的回复消息也会附带
`message_thread_id`（代表"回复线程"）。这导致：

- 普通消息 → `group_id = chat_id`
- 回复某条消息 → `group_id = chat_id::tg-topic::mt=123`

两条消息在同一群但 `group_id` 不同 → MaiBot 创建不同 session → 上下文断裂。

### 修复

仅当 `msg.is_topic_message == true`（即真的是 Forum Topic）时才将
`message_thread_id` 编入虚拟 `group_id`。普通回复线程的 `message_thread_id`
仅在 `additional_config` 中透传，供出站 `reply_parameters` 使用，不影响 session
归属。

## Summary by Sourcery

错误修复：
- 通过仅在真正的主题消息中将 `message_thread_id` 包含在虚拟群组 ID 中，防止 Telegram 群组中对非论坛主题消息的回复创建单独会话。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent non-Forum-Topic reply messages in Telegram groups from creating separate sessions by only including message_thread_id in virtual group IDs for true topic messages.

</details>