### PR TITLE
Feat/send sticker support

### DIFF
--- a/codecs/__init__.py
+++ b/codecs/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 
+import base64
 import hashlib
 import re
 import time
@@ -215,8 +216,6 @@ class TelegramInboundCodec:
         静态贴纸额外下载字节作为 file_id 失效时的回退；动画/视频贴纸
         仅保留 file_id（其字节为 .tgs/.webm，file_id 可保证原生渲染且节省下载）。
         """
-        import base64
-
         file_id = sticker.get("file_id")
         is_animated = bool(sticker.get("is_animated"))
         is_video = bool(sticker.get("is_video"))
@@ -237,7 +236,6 @@ class TelegramInboundCodec:
     @staticmethod
     def _build_binary_segment(seg_type: str, raw_bytes: bytes) -> Dict[str, Any]:
         """构造符合 Host 规范的二进制组件段。"""
-        import base64
         return {
             "type": seg_type,
             "data": "",

--- a/codecs/__init__.py
+++ b/codecs/__init__.py
@@ -92,9 +92,9 @@ class TelegramInboundCodec:
             seg.get("data", "") for seg in segments if seg.get("type") == "text"
         )
 
-        # 判断是否包含图片/emoji
+        # 判断是否包含图片/emoji（贴纸作为表情包的细化子类型，一并计入）
         has_image = any(seg.get("type") == "image" for seg in segments)
-        has_emoji = any(seg.get("type") == "emoji" for seg in segments)
+        has_emoji = any(seg.get("type") in ("emoji", "sticker") for seg in segments)
 
         message_id = str(msg.get("message_id") or f"tg-{int(time.time() * 1000)}")
 
@@ -162,17 +162,10 @@ class TelegramInboundCodec:
                 else:
                     segs.append({"type": "text", "data": "[图片]"})
 
-        # 贴纸
+        # 贴纸：保留 file_id 供出站 sendSticker 原生渲染
         sticker = msg.get("sticker")
         if sticker:
-            if not (sticker.get("is_animated") or sticker.get("is_video")):
-                raw_bytes = await self._download_file_bytes(sticker.get("file_id"))
-                if raw_bytes:
-                    segs.append(self._build_binary_segment("emoji", raw_bytes))
-                else:
-                    segs.append({"type": "text", "data": "[贴纸]"})
-            else:
-                segs.append({"type": "text", "data": "[贴纸]"})
+            segs.append(await self._build_sticker_segment(sticker))
 
         # 动图
         animation = msg.get("animation")
@@ -215,6 +208,31 @@ class TelegramInboundCodec:
         except Exception as e:
             self._logger.warning(f"Telegram 文件下载失败: {e}")
         return None
+
+    async def _build_sticker_segment(self, sticker: Dict[str, Any]) -> Dict[str, Any]:
+        """构造贴纸段：保留 file_id 供出站 sendSticker 原生渲染。
+
+        静态贴纸额外下载字节作为 file_id 失效时的回退；动画/视频贴纸
+        仅保留 file_id（其字节为 .tgs/.webm，file_id 可保证原生渲染且节省下载）。
+        """
+        import base64
+
+        file_id = sticker.get("file_id")
+        is_animated = bool(sticker.get("is_animated"))
+        is_video = bool(sticker.get("is_video"))
+        segment: Dict[str, Any] = {
+            "type": "sticker",
+            "data": "",
+            "file_id": file_id,
+            "is_animated": is_animated,
+            "is_video": is_video,
+        }
+        if file_id and not (is_animated or is_video):
+            raw_bytes = await self._download_file_bytes(file_id)
+            if raw_bytes:
+                segment["hash"] = hashlib.sha256(raw_bytes).hexdigest()
+                segment["binary_data_base64"] = base64.b64encode(raw_bytes).decode("utf-8")
+        return segment
 
     @staticmethod
     def _build_binary_segment(seg_type: str, raw_bytes: bytes) -> Dict[str, Any]:

--- a/codecs/outbound.py
+++ b/codecs/outbound.py
@@ -178,8 +178,11 @@ class TelegramOutboundCodec:
                     )
                 if binary_b64:
                     sticker_bytes = base64.b64decode(binary_b64)
+                    sticker_format = "video" if seg.get("is_video") else (
+                        "animated" if seg.get("is_animated") else "static"
+                    )
                     return await self._tg.send_sticker_bytes(
-                        chat_id, sticker_bytes, reply_to=reply_to,
+                        chat_id, sticker_bytes, sticker_format=sticker_format, reply_to=reply_to,
                         message_thread_id=message_thread_id,
                         direct_messages_topic_id=direct_messages_topic_id,
                     )

--- a/codecs/outbound.py
+++ b/codecs/outbound.py
@@ -167,6 +167,23 @@ class TelegramOutboundCodec:
                         direct_messages_topic_id=direct_messages_topic_id,
                     )
                 return {"ok": False}
+            elif seg_type == "sticker":
+                # file_id 优先（原生渲染，静态/动画/视频通吃），字节回退（仅静态贴纸）
+                file_id = seg.get("file_id")
+                if file_id:
+                    return await self._tg.send_sticker_file_id(
+                        chat_id, file_id, reply_to=reply_to,
+                        message_thread_id=message_thread_id,
+                        direct_messages_topic_id=direct_messages_topic_id,
+                    )
+                if binary_b64:
+                    sticker_bytes = base64.b64decode(binary_b64)
+                    return await self._tg.send_sticker_bytes(
+                        chat_id, sticker_bytes, reply_to=reply_to,
+                        message_thread_id=message_thread_id,
+                        direct_messages_topic_id=direct_messages_topic_id,
+                    )
+                return {"ok": False}
             elif self._is_local_only_segment(seg):
                 # 这些类型只参与本地语义，不直接发送到 Telegram
                 return {"ok": True}

--- a/telegram_client.py
+++ b/telegram_client.py
@@ -265,21 +265,37 @@ class TelegramClient:
         async with session.post(self._url("sendSticker"), json=payload, proxy=self._http_proxy()) as resp:
             return await resp.json()
 
+    # sticker_format -> (filename, content_type)
+    _STICKER_FORMAT_META = {
+        "static": ("sticker.webp", "image/webp"),
+        "animated": ("sticker.tgs", "application/x-tgsticker"),
+        "video": ("sticker.webm", "video/webm"),
+    }
+
     async def send_sticker_bytes(
         self,
         chat_id: int | str,
         sticker_bytes: bytes,
+        sticker_format: str = "static",
         reply_to: Optional[int] = None,
         message_thread_id: Optional[int] = None,
         direct_messages_topic_id: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """以 multipart 上传新贴纸字节（.webp/.tgs/.webm），作为 file_id 不可用时的回退。"""
+        """以 multipart 上传新贴纸字节，作为 file_id 不可用时的回退。
+
+        sticker_format 取值与 Telegram sticker_format 一致：
+        ``static``(.webp)、``animated``(.tgs)、``video``(.webm)，
+        决定上传文件名与 Content-Type，避免非 WebP 贴纸被 Telegram 拒收。
+        """
+        filename, content_type = self._STICKER_FORMAT_META.get(
+            sticker_format, self._STICKER_FORMAT_META["static"]
+        )
         session = await self.ensure_session()
         form = aiohttp.FormData()
         form.add_field("chat_id", str(chat_id))
         self._append_reply_form(form, reply_to)
         self._append_topic_form(form, message_thread_id, direct_messages_topic_id)
-        form.add_field("sticker", sticker_bytes, filename="sticker.webp", content_type="image/webp")
+        form.add_field("sticker", sticker_bytes, filename=filename, content_type=content_type)
         async with session.post(self._url("sendSticker"), data=form, proxy=self._http_proxy()) as resp:
             return await resp.json()
 

--- a/telegram_client.py
+++ b/telegram_client.py
@@ -249,6 +249,40 @@ class TelegramClient:
         async with session.post(self._url("sendAnimation"), data=form, proxy=self._http_proxy()) as resp:
             return await resp.json()
 
+    async def send_sticker_file_id(
+        self,
+        chat_id: int | str,
+        file_id: str,
+        reply_to: Optional[int] = None,
+        message_thread_id: Optional[int] = None,
+        direct_messages_topic_id: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """以 file_id 发送已存在于 Telegram 服务端的贴纸（原生渲染，静态/动画/视频通吃）。"""
+        session = await self.ensure_session()
+        payload: Dict[str, Any] = {"chat_id": chat_id, "sticker": file_id}
+        self._append_reply(payload, reply_to)
+        self._append_topic(payload, message_thread_id, direct_messages_topic_id)
+        async with session.post(self._url("sendSticker"), json=payload, proxy=self._http_proxy()) as resp:
+            return await resp.json()
+
+    async def send_sticker_bytes(
+        self,
+        chat_id: int | str,
+        sticker_bytes: bytes,
+        reply_to: Optional[int] = None,
+        message_thread_id: Optional[int] = None,
+        direct_messages_topic_id: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """以 multipart 上传新贴纸字节（.webp/.tgs/.webm），作为 file_id 不可用时的回退。"""
+        session = await self.ensure_session()
+        form = aiohttp.FormData()
+        form.add_field("chat_id", str(chat_id))
+        self._append_reply_form(form, reply_to)
+        self._append_topic_form(form, message_thread_id, direct_messages_topic_id)
+        form.add_field("sticker", sticker_bytes, filename="sticker.webp", content_type="image/webp")
+        async with session.post(self._url("sendSticker"), data=form, proxy=self._http_proxy()) as resp:
+            return await resp.json()
+
     async def send_video_url(
         self,
         chat_id: int | str,


### PR DESCRIPTION
## Summary by Sourcery

通过在入站消息中保留贴纸元数据，并在出站时通过专用 API 发送贴纸（优先使用 `file_id`，必要时回退到字节上传），新增对原生 Telegram 贴纸的支持。

新功能：
- 支持将贴纸作为独立的消息段类型，包括静态贴纸、动态贴纸和视频贴纸。
- 支持通过 `file_id` 发送 Telegram 贴纸，并在需要时回退到通过字节上传贴纸的路径。

增强：
- 在判断消息是否包含表情符号或类图片内容时，将贴纸与表情符号一并计数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add native Telegram sticker support by preserving sticker metadata on inbound messages and sending stickers through dedicated outbound APIs with file_id-first handling and byte-based fallback.

New Features:
- Support stickers as a distinct message segment type, including static, animated, and video stickers.
- Enable outbound sending of Telegram stickers via file_id with a fallback path that uploads sticker bytes when necessary.

Enhancements:
- Count stickers alongside emojis when determining whether a message contains emoji or image-like content.

</details>