### PR TITLE
feat: 补充 sendSticker 支持，修复贴纸/表情包退化为文件的问题

### DIFF
--- a/codecs/outbound.py
+++ b/codecs/outbound.py
@@ -102,6 +102,25 @@ class TelegramOutboundCodec:
         return seg_type in {"reply", "at", "forward", "dict"}
 
     @staticmethod
+    def _detect_image_format(data: bytes) -> str:
+        """通过文件头魔数识别图片/贴纸格式。
+
+        Returns:
+            ``gif`` | ``png`` | ``webp`` | ``jpeg`` | ``unknown``
+        """
+        if len(data) < 12:
+            return "unknown"
+        if data[:4] == b"GIF8":
+            return "gif"
+        if data[:4] == b"\x89PNG":
+            return "png"
+        if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+            return "webp"
+        if data[:3] == b"\xff\xd8\xff":
+            return "jpeg"
+        return "unknown"
+
+    @staticmethod
     def _format_send_error(seg: Dict[str, Any], result: Dict[str, Any]) -> str:
         seg_type = str(seg.get("type") or "unknown").strip() or "unknown"
         description = str(
@@ -159,14 +178,28 @@ class TelegramOutboundCodec:
                     )
                 return {"ok": False}
             elif seg_type == "emoji":
-                if binary_b64:
-                    anim_bytes = base64.b64decode(binary_b64)
+                if not binary_b64:
+                    return {"ok": False}
+                raw_bytes = base64.b64decode(binary_b64)
+                fmt = self._detect_image_format(raw_bytes)
+                if fmt == "gif":
                     return await self._tg.send_animation_bytes(
-                        chat_id, anim_bytes, reply_to=reply_to,
+                        chat_id, raw_bytes, reply_to=reply_to,
                         message_thread_id=message_thread_id,
                         direct_messages_topic_id=direct_messages_topic_id,
                     )
-                return {"ok": False}
+                if fmt in ("png", "webp"):
+                    return await self._tg.send_sticker_bytes(
+                        chat_id, raw_bytes, sticker_format="static", reply_to=reply_to,
+                        message_thread_id=message_thread_id,
+                        direct_messages_topic_id=direct_messages_topic_id,
+                    )
+                # jpeg / unknown → photo 兜底
+                return await self._tg.send_photo_bytes(
+                    chat_id, raw_bytes, reply_to=reply_to,
+                    message_thread_id=message_thread_id,
+                    direct_messages_topic_id=direct_messages_topic_id,
+                )
             elif seg_type == "sticker":
                 # file_id 优先（原生渲染，静态/动画/视频通吃），字节回退（仅静态贴纸）
                 file_id = seg.get("file_id")


### PR DESCRIPTION
## 问题

Closes #19

### 根因
贴纸（sticker）和表情包（emoji segment）在出站时路由错误：
- **sticker 段**：不存在，入站被包装为 emoji，file_id 丢失
- **emoji 段**：无条件走 `sendAnimation`，但实际数据可能是 PNG/WebP 静态图，Telegram 无法渲染为动画，降级为常规文件

## 修复

### 1. TelegramClient 补充 sendSticker 能力
- `send_sticker_file_id`：以 file_id 发送服务端已存在贴纸（官方推荐，静态/动画/视频通吃）
- `send_sticker_bytes`：multipart 上传，`sticker_format` 参数派生正确的 filename/Content-Type

### 2. 入站 codec 保留贴纸元信息
- 构造独立 `sticker` 段，保留 `file_id` + `is_animated/is_video`
- 静态贴纸额外下载字节作回退，动画/视频仅保留 file_id
- `has_emoji` 将 sticker 计入，保持上游语义兼容

### 3. 出站 codec 路由
- `sticker` 段：file_id 优先 → 字节回退（按 is_animated/is_video 派生格式）
- `emoji` 段：魔数检测 → GIF→sendAnimation / PNG,WebP→sendSticker / JPEG,其他→sendPhoto

## 验证
- py_compile + ruff 全过
- 临时脚本覆盖：静态/动画/视频贴纸入站、出站 file_id 优先/字节回退/格式派生、emoji 魔数路由（GIF/PNG/WebP/JPEG/未知）

## Summary by Sourcery

通过检测图片格式并路由到合适的 Telegram 发送方法，改进外发 emoji 和贴纸的处理。

Bug 修复：
- 确保带有静态 PNG/WebP 内容的 emoji 段以贴纸形式发送，而不是会退化为文件的动画。
- 对于 JPEG 或未知格式的回退 emoji 段，改为发送照片消息，以避免被错误地当作动画处理。

增强功能：
- 为外发的 emoji/贴纸字节添加基于文件魔数（magic-number）的图片格式检测，以选择正确的 Telegram 发送 API。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve outbound emoji and sticker handling by detecting image format and routing to the appropriate Telegram send method.

Bug Fixes:
- Ensure emoji segments with static PNG/WebP content are sent as stickers instead of animations that degrade to files.
- Fallback emoji segments with JPEG or unknown formats to photo messages to avoid incorrect animation handling.

Enhancements:
- Add magic-number based image format detection for outbound emoji/sticker bytes to choose the correct Telegram send API.

</details>